### PR TITLE
Fix AutoComplete for Location in Checkin

### DIFF
--- a/app/views/asset_check_ins/new.rhtml
+++ b/app/views/asset_check_ins/new.rhtml
@@ -26,5 +26,5 @@
 <% end %>
 
 <script type="text/javascript">
-  new Autocomplete('asset_check_in_location', { serviceUrl: '<%= loclist_equipment_asset_asset_check_ins_path([@equipment_asset, @asset_check_in]) %>' });
+  new Autocomplete('asset_check_in_location', { serviceUrl: '<%= loclist_equipment_asset_asset_check_ins_path([@equipment_asset]) %>' });
 </script>


### PR DESCRIPTION
This fixes the 404-errors caused by the wrong wrong path generated for the last known locations
