### PR TITLE
Fix exception in helper on asset check in via mobile.

### DIFF
--- a/app/helpers/asset_check_ins_helper.rb
+++ b/app/helpers/asset_check_ins_helper.rb
@@ -20,7 +20,7 @@ module AssetCheckInsHelper
     jqm_data = { 'data-role' => "button" }
     jqm_data.merge!(options.except(:icon,:pos,:footer))
     jqm_data['data-icon'] = options[:icon] if options.has_key?(:icon)
-    if options[:pos] && options[:pos][0].upcase == "R"
+    if options[:pos] && options[:pos][0].to_s.upcase == "R"
       jqm_data[:class] = "" unless jqm_data.has_key?(:class)
       jqm_data[:class] += " ui-btn-right"
     end


### PR DESCRIPTION
On an instance of redmine at a job of mine with current plugin version, an exception was raised when requesting `/equipment_assets/3/asset_check_ins/new` via mobile:
https://gist.github.com/49429169c688c3033771

I did a quick fix for this without really understanding, why `options[:pos][0]` is `Fixnum`, here, but I think, this not breaking anything.
